### PR TITLE
Hydrates with its own entity instance

### DIFF
--- a/src/HydratingArrayPaginator.php
+++ b/src/HydratingArrayPaginator.php
@@ -57,7 +57,7 @@ class HydratingArrayPaginator extends ArrayPaginator
 
         $collection = array();
         foreach ($set as $item) {
-            $collection[] = $this->hydrator->hydrate($item, $this->entityPrototype);
+            $collection[] = $this->hydrator->hydrate($item, clone $this->entityPrototype);
         }
         return $collection;
     }


### PR DESCRIPTION
Looks like the collection item was hydrated with an referenced entity instance.
David Stockton gives me a hint [here](https://groups.google.com/a/zend.com/forum/#!topic/apigility-users/AFi5QyRsqBg) on google groups. 
