### PR TITLE
Zend\Hydrator\HydratorInterface instead of Stdlib

### DIFF
--- a/src/StatusLib/HydratingArrayPaginator.php
+++ b/src/StatusLib/HydratingArrayPaginator.php
@@ -8,7 +8,7 @@ namespace StatusLib;
 
 use stdClass;
 use Zend\Paginator\Adapter\ArrayAdapter as ArrayPaginator;
-use Zend\Stdlib\Hydrator\HydratorInterface;
+use Zend\Hydrator\HydratorInterface;
 
 /**
  * Specialized Zend\Paginator\Adapter\ArrayAdapter instance for returning


### PR DESCRIPTION
To avoid the following error:
```bash
Catchable fatal error: Argument 2 passed to StatusLib\HydratingArrayPaginator::__construct() must be an instance of Zend\Stdlib\Hydrator\HydratorInterface, instance of Zend\Hydrator\ObjectProperty given, called in C:\Users\juan_\workspace_php\pblapi\pblapi_apigility\apigility\vendor\zfcampus\statuslib-example\src\StatusLib\ArrayMapper.php on line 173 and defined in C:\Users\juan_\workspace_php\pblapi\pblapi_apigility\apigility\vendor\zfcampus\statuslib-example\src\StatusLib\HydratingArrayPaginator.php on line 34
```