### PR TITLE
Updates the zf/zend-config dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ramsey/uuid": "^2.8",
-        "zendframework/zend-config": "^2.6",
+        "zendframework/zend-config": "^3.1",
         "zendframework/zend-db": "^2.8.2",
         "zendframework/zend-paginator": "^2.7",
         "zendframework/zend-hydrator": "^1.1 || ^2.0",


### PR DESCRIPTION
Hello Matthew,

I'm sending this pull request to you in order to fix a minor dependency issue that breaks this module's installation within Apigility when using Composer.

This PR fixes:
* sets the zf/zend-config minimum requirement to 3.1.

It was great meeting you at GrumpyConf!

Best regards,

Andrew Caya
ZCE, ZCA