### PR TITLE
Allow usage with zend-hydrator v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "zendframework/zend-config": "^2.6",
         "zendframework/zend-db": "^2.8.2",
         "zendframework/zend-paginator": "^2.7",
-        "zendframework/zend-hydrator": "^1.1 || ^2.0",
+        "zendframework/zend-hydrator": "^1.1 || ^2.0 || ^3.0",
         "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1",
         "zfcampus/zf-configuration": "^1.0"
     },

--- a/src/ArrayMapper.php
+++ b/src/ArrayMapper.php
@@ -8,10 +8,11 @@ namespace StatusLib;
 
 use DomainException;
 use InvalidArgumentException;
-use Traversable;
 use Rhumsaa\Uuid\Uuid;
+use Traversable;
+use Zend\Hydrator\ObjectProperty;
+use Zend\Hydrator\ObjectPropertyHydrator;
 use Zend\Stdlib\ArrayUtils;
-use Zend\Hydrator\ObjectProperty as ObjectPropertyHydrator;
 use ZF\Configuration\ConfigResource;
 
 /**
@@ -35,7 +36,7 @@ class ArrayMapper implements MapperInterface
     protected $entityPrototype;
 
     /**
-     * @var ObjectPropertyHydrator
+     * @var ObjectProperty|ObjectPropertyHydrator
      */
     protected $hydrator;
 
@@ -48,7 +49,11 @@ class ArrayMapper implements MapperInterface
         $this->data = $data;
         $this->configResource = $configResource;
 
-        $this->hydrator = new ObjectPropertyHydrator();
+        $hydratorClass = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectProperty::class;
+        $this->hydrator = new $hydratorClass();
+
         $this->entityPrototype = new Entity;
     }
 

--- a/src/TableGateway.php
+++ b/src/TableGateway.php
@@ -9,7 +9,8 @@ namespace StatusLib;
 use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\ResultSet\HydratingResultSet;
 use Zend\Db\TableGateway\TableGateway as ZFTableGateway;
-use Zend\Hydrator\ObjectProperty as ObjectPropertyHydrator;
+use Zend\Hydrator\ObjectProperty;
+use Zend\Hydrator\ObjectPropertyHydrator;
 
 /**
  * Custom TableGateway instance for StatusLib
@@ -20,7 +21,10 @@ class TableGateway extends ZFTableGateway
 {
     public function __construct($table, AdapterInterface $adapter, $features = null)
     {
-        $resultSet = new HydratingResultSet(new ObjectPropertyHydrator(), new Entity());
+        $hydratorClass = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectPropertyHydrator::class;
+        $resultSet = new HydratingResultSet(new $hydratorClass(), new Entity());
         return parent::__construct($table, $adapter, $features, $resultSet);
     }
 }


### PR DESCRIPTION
This patch adds version 3 releases to the zend-hydrator constraint. In
order for the code to work without deprecation notices, it also updates
the `ArrayMapper` and `TableGateway` classes to vary which version of
the object property hydrator to use, based on zend-hydrator version
detected.